### PR TITLE
fix(preview): respect same-origin link embeds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+## Scope
+
+Project-local instructions for TabBoost, a Manifest V3 Chrome extension. Follow the shared global agent rules first, then these repository-specific rules.
+
+## Project Shape
+
+- Package manager: npm. This repo has `package-lock.json`; use `npm ci`, `npm test`, `npm run build`, and `npm run validate`.
+- Runtime: Chrome Extension Manifest V3.
+- Main surfaces:
+  - `src/js/background.js`: service worker, Chrome APIs, commands, DNR ruleset toggling, extension messages.
+  - `src/js/contentScript.js`: page-injected behavior, link preview popup, save shortcut interception.
+  - `src/js/splitView/`: split view implementation.
+  - `src/popup/` and `src/options/`: extension UI.
+  - `rules/`: static Declarative Net Request rules.
+- Build output: `build/`. Load this directory as the unpacked extension for local verification.
+
+## Chrome Extension Debugging
+
+Do not start with a patch. Convert every browser symptom into a layer-specific failure first.
+
+For link preview, separate these layers:
+
+1. Source page policy: the page hosting TabBoost may block child frames through its own `Content-Security-Policy`, especially `frame-src`.
+2. Redirect layer: short links such as `https://t.co/...` may redirect before the final target is reached.
+3. Target page policy: the final target may block embedding through `X-Frame-Options` or `Content-Security-Policy: frame-ancestors`.
+4. Extension runtime: DNR rulesets, storage settings, service worker logs, content script logs, and iframe load detection may disagree.
+
+Required evidence before fixing iframe/link-preview bugs:
+
+- Source page URL.
+- Clicked link selector, visible text, or exact `href`.
+- Whether the issue is Chrome Web Store build or local `build/`.
+- Extension service worker output for:
+  - `await chrome.storage.sync.get({ headerModificationEnabled: true })`
+  - `await chrome.declarativeNetRequest.getEnabledRulesets()`
+- Source page DevTools Console errors, especially `Refused to frame` or CSP violations.
+- Source page Network evidence:
+  - main document response headers;
+  - whether the main document is `from service worker`;
+  - iframe/redirect requests, if any;
+  - final target response headers.
+
+If Network shows the main document is `from service worker`, verify the same repro with DevTools `Application -> Service Workers -> Bypass for network`. This distinguishes a site service-worker path from an extension DNR/header-modification path.
+
+For this class of bug, "Page loaded" in the popup is not proof of success. An iframe `load` event may still display a Chrome blocked page. Treat user-visible blocked content, Console CSP errors, and Network request absence as stronger evidence than the popup title.
+
+Use Chrome CDP or DevTools for browser verification. Do not scaffold Playwright/Puppeteer for ad-hoc extension debugging unless this repo already owns that test path.
+
+## Verification
+
+For code changes, run the narrowest meaningful check first, then the repo gate:
+
+- Unit-level change: `npm test -- <matching test file or pattern>`.
+- Extension behavior change: `npm run build`, load `build/` as unpacked extension, and re-check the exact browser symptom.
+- Release-readiness change: `npm run validate`.
+
+Do not claim a Chrome extension behavior is fixed without a fresh browser repro or an explicit statement that browser verification was not possible.

--- a/manifest.json
+++ b/manifest.json
@@ -46,7 +46,7 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.google.com; default-src 'self'; connect-src 'self' https://*.google.com; frame-src 'self'; font-src 'self'; form-action 'none'; base-uri 'none'; upgrade-insecure-requests;",
+    "extension_pages": "script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.google.com; default-src 'self'; connect-src 'self' https://*.google.com; frame-src 'self' http: https:; font-src 'self'; form-action 'none'; base-uri 'none'; upgrade-insecure-requests;",
     "sandbox": "sandbox allow-scripts allow-forms allow-popups allow-modals; script-src 'self'; object-src 'none'"
   },
   "action": {
@@ -104,7 +104,8 @@
       ],
       "matches": [
         "<all_urls>"
-      ]
+      ],
+      "use_dynamic_url": true
     }
   ]
 }

--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -7,6 +7,7 @@ import {
   LOAD_EXTENSION_SCRIPT_ACTION,
 } from "../utils/messageChannels.js";
 import { shouldBypass, DEFAULT_BLOCKLIST } from "../utils/siteBlocklist.js";
+import { buildPreviewFrameUrl } from "../utils/preview-frame.js";
 
 /* global __webpack_public_path__ */
 
@@ -850,12 +851,17 @@ async function createPopupDOM(url) {
       resetBeforeLoad();
 
       try {
+        const previewUrl = buildPreviewFrameUrl(url);
+        if (!previewUrl) {
+          throw new Error(getMessage("cannotLoadInPopup") || "Invalid preview URL");
+        }
+
         const loadPromise = loadWithTimeout(
           iframe,
-          url,
+          previewUrl,
           POPUP_IFRAME_TIMEOUT_MS
         );
-        iframe.src = url;
+        iframe.src = previewUrl;
         const loadResult = await loadPromise;
 
         if (hasHandledFailure) {

--- a/src/js/splitView/splitViewDOM.js
+++ b/src/js/splitView/splitViewDOM.js
@@ -9,6 +9,7 @@ import {
   createCloseButton,
 } from "./splitViewDOMUtils.js";
 import { safeQuerySelector } from "./splitViewUtils.js";
+import { buildPreviewFrameUrl } from "../../utils/preview-frame.js";
 import * as i18n from "../../utils/i18n.js";
 import {
   createSettingsButton,
@@ -344,7 +345,7 @@ export function updateRightViewDOM(url) {
       setupIframeEvents(rightIframe, errorContainer, url);
       rightView.appendChild(rightIframe);
     } else {
-      rightIframe.src = url;
+      rightIframe.src = buildPreviewFrameUrl(url) || "about:blank";
       if (errorContainer) {
         updateErrorButtons(errorContainer, url);
       }

--- a/src/js/splitView/splitViewDOMUtils.js
+++ b/src/js/splitView/splitViewDOMUtils.js
@@ -1,5 +1,6 @@
 import { UI_CONFIG } from "./splitViewConfig";
 import { safeQuerySelector } from "./splitViewUtils";
+import { buildPreviewFrameUrl } from "../../utils/preview-frame.js";
 
 /**
  * Create a DOM element with optional configuration
@@ -63,12 +64,16 @@ export function addSafeEventListener(element, event, handler) {
  * @returns {HTMLIFrameElement} - Configured iframe
  */
 export function createIframe(id, url = "about:blank") {
+  const frameUrl =
+    url === "about:blank"
+      ? url
+      : buildPreviewFrameUrl(url);
   const config = {
     ...UI_CONFIG.iframe,
     id,
     attributes: {
       ...UI_CONFIG.iframe.attributes,
-      src: url,
+      src: frameUrl || "about:blank",
     },
   };
 

--- a/src/preview/preview.html
+++ b/src/preview/preview.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TabBoost Preview</title>
+    <style>
+      html,
+      body,
+      #preview-frame {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+      }
+
+      body {
+        overflow: hidden;
+        background: #fff;
+      }
+
+      #preview-frame {
+        display: block;
+        border: 0;
+      }
+
+      #preview-error {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+        gap: 12px;
+        font: 14px system-ui, -apple-system, sans-serif;
+        color: #374151;
+        background: #fff;
+      }
+
+      #preview-error[hidden],
+      #preview-frame[hidden] {
+        display: none;
+      }
+
+      #preview-open-tab {
+        border: 0;
+        border-radius: 6px;
+        padding: 8px 12px;
+        background: #2563eb;
+        color: #fff;
+        cursor: pointer;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="preview-error" hidden>
+      <p id="preview-error-message">Cannot load this website in preview.</p>
+      <button id="preview-open-tab" type="button">Open in new tab</button>
+    </div>
+    <iframe id="preview-frame" title="TabBoost preview"></iframe>
+  </body>
+</html>

--- a/src/preview/preview.js
+++ b/src/preview/preview.js
@@ -1,0 +1,25 @@
+import { getPreviewTargetUrl } from "../utils/preview-frame.js";
+
+const targetUrl = getPreviewTargetUrl();
+const frame = document.getElementById("preview-frame");
+const error = document.getElementById("preview-error");
+const errorMessage = document.getElementById("preview-error-message");
+const openTabButton = document.getElementById("preview-open-tab");
+
+function showError(message) {
+  errorMessage.textContent = message;
+  error.hidden = false;
+  frame.hidden = true;
+}
+
+if (!targetUrl) {
+  showError("Invalid preview URL.");
+} else {
+  openTabButton.addEventListener("click", () => {
+    window.open(targetUrl, "_blank", "noopener,noreferrer");
+  });
+  frame.addEventListener("error", () => {
+    showError("Cannot load this website in preview.");
+  });
+  frame.src = targetUrl;
+}

--- a/src/utils/preview-frame.js
+++ b/src/utils/preview-frame.js
@@ -1,0 +1,37 @@
+import { validateUrl } from "./url-validation.js";
+
+export function buildPreviewFrameUrl(url, embedderUrl) {
+  const { isValid, sanitizedUrl } = validateUrl(url);
+  if (!isValid) {
+    return "";
+  }
+
+  const parentUrl = embedderUrl || globalThis.location?.href || "";
+
+  if (parentUrl) {
+    try {
+      if (new URL(sanitizedUrl).origin === new URL(parentUrl).origin) {
+        return sanitizedUrl;
+      }
+    } catch {}
+  }
+
+  if (
+    typeof chrome === "undefined" ||
+    !chrome.runtime ||
+    typeof chrome.runtime.getURL !== "function"
+  ) {
+    return sanitizedUrl;
+  }
+
+  const previewUrl = new URL(chrome.runtime.getURL("preview.html"));
+  previewUrl.searchParams.set("url", sanitizedUrl);
+  return previewUrl.href;
+}
+
+export function getPreviewTargetUrl(locationSearch = window.location.search) {
+  const params = new URLSearchParams(locationSearch);
+  const rawUrl = params.get("url") || "";
+  const validationResult = validateUrl(rawUrl);
+  return validationResult.isValid ? validationResult.sanitizedUrl : "";
+}

--- a/src/utils/url-validation.js
+++ b/src/utils/url-validation.js
@@ -1,0 +1,84 @@
+import {
+  DANGEROUS_PROTOCOLS,
+  DANGEROUS_URL_PATTERNS,
+  EXCLUDED_EXTENSIONS,
+} from "../config/constants.js";
+
+export function validateUrl(url) {
+  if (!url || typeof url !== "string") {
+    return {
+      isValid: false,
+      sanitizedUrl: "",
+      message: "URL must be a non-empty string",
+    };
+  }
+
+  url = url.trim();
+
+  if (url.length === 0) {
+    return {
+      isValid: false,
+      sanitizedUrl: "",
+      message: "URL cannot be empty",
+    };
+  }
+
+  if (
+    DANGEROUS_PROTOCOLS.some((protocol) =>
+      url.toLowerCase().startsWith(protocol)
+    )
+  ) {
+    return {
+      isValid: false,
+      sanitizedUrl: "",
+      message: "URL uses an unsafe protocol",
+    };
+  }
+
+  if (!url.startsWith("http://") && !url.startsWith("https://")) {
+    if (url.includes("://")) {
+      return {
+        isValid: false,
+        sanitizedUrl: "",
+        message: "Only HTTP and HTTPS protocols are allowed",
+      };
+    }
+    url = "https://" + url;
+  }
+
+  try {
+    const urlObj = new URL(url);
+    const pathname = urlObj.pathname.toLowerCase();
+
+    if (EXCLUDED_EXTENSIONS.some((ext) => pathname.endsWith(ext))) {
+      return {
+        isValid: false,
+        sanitizedUrl: "",
+        message: "This file type is not supported",
+      };
+    }
+
+    if (DANGEROUS_URL_PATTERNS.length > 0) {
+      const fullUrl = urlObj.href.toLowerCase();
+      if (DANGEROUS_URL_PATTERNS.some((pattern) => fullUrl.includes(pattern))) {
+        return {
+          isValid: false,
+          sanitizedUrl: "",
+          message: "URL contains potential dangerous patterns",
+        };
+      }
+    }
+
+    return {
+      isValid: true,
+      sanitizedUrl: urlObj.href,
+      message: "Valid URL",
+    };
+  } catch (error) {
+    return {
+      isValid: false,
+      sanitizedUrl: "",
+      message: "Invalid URL format",
+    };
+  }
+}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,3 +1,5 @@
+export { validateUrl } from "./url-validation.js";
+
 export async function getCurrentTab() {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   return tab;
@@ -36,95 +38,5 @@ export async function showNotification(message) {
     });
   } catch (error) {
     console.error("Error displaying notification:", error);
-  }
-}
-
-import {
-  DANGEROUS_PROTOCOLS,
-  DANGEROUS_URL_PATTERNS,
-  EXCLUDED_EXTENSIONS,
-} from "../config/constants.js";
-
-/**
- * Verify if the URL is safe and valid
- * @param {string} url
- * @returns {{isValid: boolean, sanitizedUrl: string, message: string}}
- */
-export function validateUrl(url) {
-  if (!url || typeof url !== "string") {
-    return {
-      isValid: false,
-      sanitizedUrl: "",
-      message: "URL must be a non-empty string",
-    };
-  }
-
-  url = url.trim();
-
-  if (url.length === 0) {
-    return {
-      isValid: false,
-      sanitizedUrl: "",
-      message: "URL cannot be empty",
-    };
-  }
-
-  if (
-    DANGEROUS_PROTOCOLS.some((protocol) =>
-      url.toLowerCase().startsWith(protocol)
-    )
-  ) {
-    return {
-      isValid: false,
-      sanitizedUrl: "",
-      message: "URL uses an unsafe protocol",
-    };
-  }
-
-  if (!url.startsWith("http://") && !url.startsWith("https://")) {
-    if (url.includes("://")) {
-      return {
-        isValid: false,
-        sanitizedUrl: "",
-        message: "Only HTTP and HTTPS protocols are allowed",
-      };
-    }
-    url = "https://" + url;
-  }
-
-  try {
-    const urlObj = new URL(url);
-
-    const pathname = urlObj.pathname.toLowerCase();
-    if (EXCLUDED_EXTENSIONS.some((ext) => pathname.endsWith(ext))) {
-      return {
-        isValid: false,
-        sanitizedUrl: "",
-        message: "This file type is not supported",
-      };
-    }
-
-    if (DANGEROUS_URL_PATTERNS.length > 0) {
-      const fullUrl = urlObj.href.toLowerCase();
-      if (DANGEROUS_URL_PATTERNS.some((pattern) => fullUrl.includes(pattern))) {
-        return {
-          isValid: false,
-          sanitizedUrl: "",
-          message: "URL contains potential dangerous patterns",
-        };
-      }
-    }
-
-    return {
-      isValid: true,
-      sanitizedUrl: urlObj.href,
-      message: "Valid URL",
-    };
-  } catch (error) {
-    return {
-      isValid: false,
-      sanitizedUrl: "",
-      message: "Invalid URL format",
-    };
   }
 }

--- a/tests/unit/previewFrame.test.js
+++ b/tests/unit/previewFrame.test.js
@@ -1,0 +1,56 @@
+import {
+  buildPreviewFrameUrl,
+  getPreviewTargetUrl,
+} from "../../src/utils/preview-frame.js";
+
+describe("preview frame URLs", () => {
+  const originalGetURL = chrome.runtime.getURL;
+
+  beforeEach(() => {
+    chrome.runtime.getURL = jest.fn((path) => `chrome-extension://test-id/${path}`);
+  });
+
+  afterEach(() => {
+    chrome.runtime.getURL = originalGetURL;
+  });
+
+  test("wraps a remote URL in the extension preview page", () => {
+    const result = buildPreviewFrameUrl("https://example.com/path?q=1");
+
+    expect(result).toBe(
+      "chrome-extension://test-id/preview.html?url=https%3A%2F%2Fexample.com%2Fpath%3Fq%3D1"
+    );
+  });
+
+  test("keeps same-origin targets in the host page frame", () => {
+    const result = buildPreviewFrameUrl(
+      "https://x.com/yihong0618/status/2071365495505432840",
+      "https://x.com/dingyi/status/2071386326788927887"
+    );
+
+    expect(result).toBe("https://x.com/yihong0618/status/2071365495505432840");
+  });
+
+  test("wraps cross-origin targets from the host page", () => {
+    const result = buildPreviewFrameUrl(
+      "https://github.com/lycorp-jp/sim-use",
+      "https://x.com/onevcat/status/2071500722324336659"
+    );
+
+    expect(result).toBe(
+      "chrome-extension://test-id/preview.html?url=https%3A%2F%2Fgithub.com%2Flycorp-jp%2Fsim-use"
+    );
+  });
+
+  test("rejects unsupported target protocols", () => {
+    expect(buildPreviewFrameUrl("chrome://extensions")).toBe("");
+  });
+
+  test("extracts a valid target URL from preview search params", () => {
+    const result = getPreviewTargetUrl(
+      "?url=https%3A%2F%2Fexample.com%2Fpath%3Fq%3D1"
+    );
+
+    expect(result).toBe("https://example.com/path?q=1");
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ module.exports = {
     options: "./src/options/options.js",
     background: "./src/js/background.js",
     contentScript: "./src/js/contentScript.js",
+    preview: "./src/preview/preview.js",
   },
   output: {
     path: path.resolve(__dirname, "build"),
@@ -71,6 +72,11 @@ module.exports = {
         cssPath: "./assets/styles/options.css",
       },
     }),
+    new HtmlWebpackPlugin({
+      template: "./src/preview/preview.html",
+      filename: "preview.html",
+      chunks: ["preview"],
+    }),
     new CopyWebpackPlugin({
       patterns: [
         {
@@ -114,6 +120,8 @@ module.exports = {
               const requiredResources = new Set([
                 "assets/styles/splitViewStyles.css",
                 "split-view-controller.js",
+                "preview.html",
+                "preview.js",
               ]);
 
               manifest.web_accessible_resources[0].resources = Array.from(


### PR DESCRIPTION
### What's changed?

- Route cross-origin link previews through an extension-owned preview page while keeping same-origin targets embedded directly in the host page.
- Apply the same preview URL strategy to popup previews and split view iframes.
- Add TabBoost-specific debugging notes and regression coverage for preview URL behavior.

### Why

- Source-page CSP can block redirected links before target header rules apply, while same-origin X links must keep an X parent frame to satisfy `SAMEORIGIN` and `frame-ancestors` policies.

### Validation

- `npm test -- --runInBand`
- `npm run validate`

Not run: live X browser repro in the user's logged-in Chrome session.
